### PR TITLE
Add Bandit and Flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: lint
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: set up python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: install Python dependencies
+      run: pip install bandit flake8
+
+    - name: run flake8
+      run: flake8 leihsldap
+
+    - name: run bandit
+      run: bandit -r leihsldap

--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -1,5 +1,4 @@
 from ldap3 import Server, Connection, ALL
-from ldap3.core.exceptions import LDAPBindError
 from flask import Flask, request, redirect, render_template
 
 from leihsldap.authenticator import authenticate, token_data
@@ -35,7 +34,7 @@ def verify_password(username, password):
             config('ldap', 'search_filter').format(username=username),
             attributes=['sn', 'givenName', 'mail'])
     if len(conn.entries) != 1:
-        raise ValueError('Search must return exactly one result:', conn.entries)
+        raise ValueError('Search must return exactly one result', conn.entries)
     return conn.entries[0]
 
 


### PR DESCRIPTION
This patch adds a GitHub Actions workflow to run `flake8` and `bandit` on all pull requests for style checking, linting and static code analysis.

This fixes #1
This fixes #2