### PR TITLE
Add --config option

### DIFF
--- a/leihsldap/__main__.py
+++ b/leihsldap/__main__.py
@@ -1,5 +1,24 @@
-from leihsldap.web import app
+import argparse
+
+from leihsldap.config import update_configuration
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='LDAP based authentication handler for Leihs',
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        '-c', '--config',
+        type=str,
+        default=None,
+        help='Path to a configuration file'
+    )
+    args = parser.parse_args()
+    if args.config:
+        update_configuration(args.config)
+
+    # Since `app` will use the configuration,
+    # load it only after we updated the configuration location
+    from leihsldap.web import app
     app.run()

--- a/leihsldap/config.py
+++ b/leihsldap/config.py
@@ -31,12 +31,13 @@ def configuration_file():
         return '/etc/leihs-ldap.yml'
 
 
-def update_configuration():
+def update_configuration(filename=None):
     '''Update configuration.
     '''
-    cfgfile = configuration_file()
+    cfgfile = filename or configuration_file()
     if not cfgfile:
         return {}
+    print(f'Loading configuration from {cfgfile}')
     with open(cfgfile, 'r') as f:
         cfg = yaml.safe_load(f)
     globals()['__config'] = cfg


### PR DESCRIPTION
This patch adds `--config` and `-c` options allowing users to specify custom configuration file locations.

This fixes #11