### PR TITLE
Have the authenticator register itself

### DIFF
--- a/leihs-ldap.yml
+++ b/leihs-ldap.yml
@@ -25,7 +25,13 @@ system:
   admin:
     user: admin@example.com
     password: SECURE_PASSWORD
-  auth_id: jwt
+  auth:
+    id: jwt
+    name: LDAP Authentication
+    description: null
+    url: http://127.0.0.1:5000
+    priority: 3
+    email_match: .*
 
 ldap:
    server: ldap.example.com

--- a/leihsldap/config.py
+++ b/leihsldap/config.py
@@ -50,7 +50,7 @@ def update_configuration(filename=None):
     return cfg
 
 
-def config(*args):
+def config(*args, allow_empty=True):
     '''Get a specific configuration value or the whole configuration, loading
     the configuration file if it was not before.
 
@@ -61,6 +61,8 @@ def config(*args):
     cfg = __config or update_configuration()
     for key in args:
         if cfg is None:
-            return
+            if allow_empty:
+                return
+            raise KeyError(f'Missing configuration key {args}')
         cfg = cfg.get(key)
     return cfg

--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -2,7 +2,7 @@ from ldap3 import Server, Connection, ALL
 from flask import Flask, request, redirect, render_template
 
 from leihsldap.authenticator import authenticate, token_data
-from leihsldap.register_user import register_user
+from leihsldap.register_user import register_user, register_auth_system
 from leihsldap.config import config
 
 flask_config = {}
@@ -45,6 +45,15 @@ def login_data(data):
         return email, login, True
     login = email.split('@', 1)[0]
     return email, login, False
+
+
+@app.before_first_request
+def before_first_request():
+    try:
+        register_auth_system()
+    except RuntimeError:
+        print('Could not register authentication system. System is likely '
+              'already registered')
 
 
 @app.route('/', methods=['GET'])


### PR DESCRIPTION
With this patch, before answering the first request, the authenticator will register itself to Leihs and make sure everything is set up correctly, instead of having the administrator set all necessary settings in the Leihs admin interface and via cURL.

This will only do the initial registration and not modify already existing authentication systems.

This fixes #8