### PR TITLE
Error Pages

### DIFF
--- a/leihsldap/authenticator.py
+++ b/leihsldap/authenticator.py
@@ -11,33 +11,21 @@ def response_url(sign_in_token_data, success_token):
 
 
 def token_data(token):
-    options = {}
-
-    # Fall back to demo token for development if one is provided
-    if not token:
-        print('Warning: Using demo token')
-        token = config('token', 'demo')
-
-    if config('token', 'allow_expired'):
-        options = {'verify_exp': False}
+    options = {'verify_exp': not config('token', 'allow_expired')}
     private_key = config('token', 'private_key')
     return jwt.decode(token, private_key, ['ES256'], options)
 
 
 def authenticate(token):
-    options = {}
-    if config('token', 'allow_expired'):
-        options = {'verify_exp': False}
-    private_key = config('token', 'private_key')
-    data = jwt.decode(token, private_key, ['ES256'], options)
-    email = data['email']
+    data = token_data(token)
 
     # generate success token
     iat = int(time.time())
     exp = iat + config('token', 'validity')
+    private_key = config('token', 'private_key')
     success_token = jwt.encode({
             'sign_in_request_token': token,
-            'email': email,
+            'email': data.get('email'),
             'iat': iat,
             'exp': exp,
             'success': True

--- a/leihsldap/error.yml
+++ b/leihsldap/error.yml
@@ -1,0 +1,28 @@
+---
+invalid_token:
+  title: Invalid Token
+  message: |
+    Invalid token provided.
+    If you have been redirected from Leihs,
+    please report this to your administrator.
+no_token:
+  title: Missing Token
+  message: |
+    No token has been provided to identify the user.
+    Return to Leihs and try logging in again.
+expired_token:
+  title: Expired Token
+  message: |
+    You log-in attempt took too long and the token provided by Leihs has expired.
+    Please return to Leihs and try again.
+invalid_credentials:
+  title: Invalid Credentials
+  message: |
+    Your username or password seems to be incorrect.
+    Please go back and try again.
+internal:
+  title: Error
+  message: |
+    An internal server error occurred.
+    This should not have happened.
+    Please report this to your administrator and try again later.

--- a/leihsldap/register_user.py
+++ b/leihsldap/register_user.py
@@ -42,7 +42,7 @@ def logout(session, csrf_token):
     session.post(url('/sign-out'), data=logout_data)
 
 
-def register_user(email, firstname=None, lastname=None, login=None):
+def register_user(email, firstname=None, lastname=None, username=None):
     session = requests.Session()
 
     csrf_token = login(session)
@@ -66,7 +66,7 @@ def register_user(email, firstname=None, lastname=None, login=None):
             'lastname': lastname,
             'account_enabled': True,
             'password_sign_in_enabled': False,
-            'login': login,
+            'login': username,
             'extended_info': None
             })
     response = session.post(url('/admin/users/'),

--- a/leihsldap/templates/error.html
+++ b/leihsldap/templates/error.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+	<head>
+		<title>{{ title }}</title>
+	</head>
+	<body style="width: 300px; margin: 100px auto;">
+		<h1>{{ title }}</h1>
+		<p>{{ message }}</p>
+		<p><a href="{{ leihs_url }}">Return to Leihs →</a></p>
+	</body>
+</html>

--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -1,5 +1,11 @@
+import os
+import yaml
+
 from ldap3 import Server, Connection, ALL
+from ldap3.core.exceptions import LDAPBindError
 from flask import Flask, request, redirect, render_template
+from functools import wraps
+from jwt.exceptions import DecodeError, ExpiredSignatureError
 
 from leihsldap.authenticator import authenticate, token_data
 from leihsldap.register_user import register_user, register_auth_system
@@ -11,6 +17,8 @@ if config('ui', 'directories', 'template'):
 if config('ui', 'directories', 'static'):
     flask_config['static_folder'] = config('ui', 'directories', 'static')
 app = Flask(__name__, **flask_config)
+
+__error = {}
 
 
 def ensure_list(var):
@@ -47,6 +55,29 @@ def login_data(data):
     return email, login, False
 
 
+def error(id, code):
+    if not __error:
+        with open(os.path.dirname(__file__) + '/error.yml', 'r') as f:
+            globals()['__error'] = yaml.safe_load(f)
+    error_data = __error.get(id).copy()
+    error_data['leihs_url'] = config('system', 'url')
+    return render_template('error.html', **error_data), code
+
+
+def handle_errors(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        try:
+            return function(*args, **kwargs)
+        except DecodeError:
+            return error('invalid_token', 400)
+        except ExpiredSignatureError:
+            return error('expired_token', 400)
+        except LDAPBindError:
+            return error('invalid_credentials', 403)
+    return wrapper
+
+
 @app.before_first_request
 def before_first_request():
     try:
@@ -56,15 +87,24 @@ def before_first_request():
               'already registered')
 
 
+@app.errorhandler(500)
+def internal_server_error(e):
+    return error('internal', 500)
+
+
 @app.route('/', methods=['GET'])
+@handle_errors
 def login_page():
     token = request.args.get('token')
+    if not token:
+        return error('no_token', 400)
     data = token_data(token)
     email, user, _ = login_data(data)
     return render_template('login.html', token=token, user=user)
 
 
 @app.route('/', methods=['POST'])
+@handle_errors
 def login():
     token = request.form.get('token')
     password = request.form.get('password')
@@ -77,5 +117,5 @@ def login():
             email,
             firstname=str(user_data['givenName']),
             lastname=str(user_data['sn']),
-            login=user)
+            username=user)
     return redirect(return_url, code=302)


### PR DESCRIPTION
This patch adds error pages for several different error types instead of always just ending up with an internal server error and only logging the real error. Pages which now have custom error pages are:

- token expired
- invalid credentials
- no token
- invalid credentials
- general error

This fixes #5