### PR TITLE
Add Fallback Email

### DIFF
--- a/leihs-ldap.yml
+++ b/leihs-ldap.yml
@@ -14,7 +14,7 @@ token:
   # How long should the issued success token be valid.
   # Shorter means more secure but also more likely to cause errors in case of slow networks.
   # Value in seconds.
-  validity: 100
+  validity: 120
 
   # Do not fail if the token received from Leihs has expired.
   # Acepting expired Token is insecure!
@@ -39,6 +39,24 @@ ldap:
    user_dn: 'uid={username},ou=people,dc=example,dc=com'
    base_dn: 'ou=people,dc=example,dc=com'
    search_filter: '(uid={username})'
+   userdata:
+     email:
+       # Use LDAP email data to overwrite the email field provided by Leihs.
+       # This can be useful, for example, if you have several domains.
+       overwrite: True
+
+       # Falls back to LDAP email if no valid email is provided from Leihs.
+       fallback: True
+
+       # LDAP attribute to use as email address.
+       field: mail
+
+     name:
+       # LDAP field specifying the user's family name
+       family: sn
+
+       # LDAP field specifying the user's given name
+       given: givenName
 
 ui:
   directories:

--- a/leihsldap/authenticator.py
+++ b/leihsldap/authenticator.py
@@ -4,21 +4,13 @@ import time
 from leihsldap.config import config
 
 
-def response_url(sign_in_token_data, success_token):
-    base_url = sign_in_token_data['server_base_url']
-    path = sign_in_token_data['path']
-    return f'{base_url}{path}?token={success_token}'
-
-
 def token_data(token):
     options = {'verify_exp': not config('token', 'allow_expired')}
     private_key = config('token', 'private_key')
     return jwt.decode(token, private_key, ['ES256'], options)
 
 
-def authenticate(token):
-    data = token_data(token)
-
+def response_url(token, data):
     # generate success token
     iat = int(time.time())
     exp = iat + config('token', 'validity')
@@ -31,4 +23,6 @@ def authenticate(token):
             'success': True
             }, private_key, 'ES256')
 
-    return data, response_url(data, success_token)
+    base_url = data['server_base_url']
+    path = data['path']
+    return f'{base_url}{path}?token={success_token}'


### PR DESCRIPTION
If a user registers using, for example, the username `testuser`, this will be sent to the authenticator as `email` field of the token. This will then later cause trouble if we send back this obviously invalid email address when registering the user and when sending the success token.

This patch allows the authenticator to use an email address provided by LDAP instead, discarding invalid email addresses along the way.

This behavior is configurable. You can:

- Disable the feature
- Only use this to replace invalid email addresses
- Always use the email address from LDAP

This fixes #18