### PR TITLE
Awitch to API Token

### DIFF
--- a/leihs-ldap.yml
+++ b/leihs-ldap.yml
@@ -22,9 +22,15 @@ token:
 
 system:
   url: https://leihs.example.com
-  admin:
-    user: admin@example.com
-    password: SECURE_PASSWORD
+
+  # To generate an API token:
+  # - In Leihs admin, go to “Users”
+  # - Select a user
+  # - Click on “User-Home in leihs/my”
+  # - Click on “API-Tokens”
+  # - Clixk “Add API-Token”
+  api_token: 00000000-1111-2222-3333-444444444444
+
   auth:
     id: jwt
     name: LDAP Authentication


### PR DESCRIPTION
This patch switches to using API tokens for communication with the Leihs API instead of logging in as a user and keeping that session for every request. This simplifies the code quite a bit and also makes communication faster since less requests are now necessary to communicate with Leihs.

This patch changes the mandatory configuration. Adopters now have to provide an API token but no longer have to provide user credentials.

This fixes #22