### PR TITLE
Introduce Type Checking on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,15 @@ jobs:
         python-version: '3.10'
 
     - name: install Python dependencies
-      run: pip install bandit flake8
+      run: |
+        pip install -r requirements.txt
+        pip install bandit flake8 pyright
 
     - name: run flake8
       run: flake8 leihsldap
 
     - name: run bandit
       run: bandit -r leihsldap
+
+    - name: run pyright
+      run: pyright --skipunannotated leihsldap


### PR DESCRIPTION
This patch makes GitHub Actions run `pyright` for basic type checking on pull requests and pushes to prevent errors. This will only check functions which have type annotations.