### PR TITLE
Add a `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Environment
+venv/
+
+# Editor
+.vscode
+*.swp


### PR DESCRIPTION
This patch adds a `.gitignore` to hide Python cache files, temporary editor files and other things we want to avoid accidentally committing.