### PR TITLE
Include Language Files in Python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE README.md requirements.txt leihsldap/error.yml leihsldap/templates/*.html leihsldap/static/*.css
+include LICENSE README.md requirements.txt leihsldap/i18n/*yml leihsldap/templates/*.html leihsldap/static/*.css

--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -53,6 +53,7 @@ def error(error_id: str, code: int) -> tuple[str, int]:
     :returns: Tuple of data for Flask response
     '''
     lang = request.accept_languages.best_match(__languages)
+    logger.debug('Using language: %s', lang)
     error_data = __error[lang][error_id].copy()
     error_data['leihs_url'] = config('leihs', 'url')
     error_data['i18n'] = __i18n[lang]


### PR DESCRIPTION
Version 0.3 released on pypi.org is missing the internationalization files.

This patch adds the missing files to the manifest file defining which files to add to the package. This should fix the tool when installed via `pip`.