### PR TITLE
Register Authenticator Directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ LDAP based authentication handler for [Leihs](https://github.com/leihs/leihs).
 
 - Provides __automatic configuration__ of the Leihs authentication system.
 
-  The authenticator will automatically register itself in Leihs before answering the first request.
-  Just open the authenticator in your browser and it will magically appear in Leihs.
+  The authenticator will automatically register itself in Leihs.
 
 ## Getting Started
 
@@ -56,10 +55,7 @@ LDAP based authentication handler for [Leihs](https://github.com/leihs/leihs).
    ❯ python -m leihsldap -c /path/to/leihs-ldap.yml
    ```
 
-4. Open the tool once in your browser.
-   For example, go to [127.0.0.1:5000](http://127.0.0.1:5000) if you run the tool locally.
-   It's not important to provide a valid token.
-   You need to do this because the tool will register itself on the first request.
+	The tool should automatically register itself in Leihs.
 
 ### Development Version
 

--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -81,13 +81,9 @@ def handle_errors(function):
     return wrapper
 
 
-@app.before_first_request
-def before_first_request():
-    '''Try registering the authentication system.
+def init():
+    '''Load internationalization and try to register the authentication system.
     '''
-    logger.info('Trying to register authentication system')
-    register_auth_system()
-
     # load internationalization data
     files = glob.glob(os.path.dirname(__file__) + '/i18n/error-*.yml')
     globals()['__languages'] = {os.path.basename(f)[6:-4] for f in files}
@@ -103,6 +99,10 @@ def before_first_request():
         i18n_file = os.path.dirname(__file__) + f'/i18n/i18n-{lang}.yml'
         with open(i18n_file, 'r') as f:
             globals()['__i18n'][lang] = yaml.safe_load(f)
+
+    # Try to register auth system
+    logger.info('Trying to register authentication system')
+    register_auth_system()
 
 
 @app.errorhandler(500)
@@ -171,3 +171,6 @@ def login():
 
     # Redirect back to Leihs with success token
     return redirect(response_url(token, data), code=302)
+
+
+init()


### PR DESCRIPTION
This patch make the authenticator register itself with Leihs directly and will no longer wait for the first request.