### PR TITLE
Remove incorrect function call

### DIFF
--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -126,7 +126,7 @@ def login_page():
         logger.debug('No token provided')
         return error('no_token', 400)
     _, email, user, _ = token_data(token)
-    i18n = __i18n[request.accept_languages.best_match(__languages)()]
+    i18n = __i18n[request.accept_languages.best_match(__languages)]
     return render_template('login.html', token=token, user=user, i18n=i18n)
 
 


### PR DESCRIPTION
This patch removes a set of brackets since you can't call a string. This was leading to an irrecoverable error during the login process.