### PR TITLE
Accept users with no name

### DIFF
--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -165,8 +165,8 @@ def login():
     # Make sure user is registered with Leihs
     register_user(
             email,
-            firstname=user_data['givenName'][0],
-            lastname=user_data['sn'][0],
+            firstname=(user_data['givenName'] or [None])[0],
+            lastname=(user_data['sn'] or [None])[0],
             username=user,
             groups=groups)
 


### PR DESCRIPTION
This patch allows users to have no given or family name set in LDAP. Such users can now still register.