### PR TITLE
Use correct config values for register_user call

### DIFF
--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -165,8 +165,8 @@ def login():
     # Make sure user is registered with Leihs
     register_user(
             email,
-            firstname=(user_data['givenName'] or [None])[0],
-            lastname=(user_data['sn'] or [None])[0],
+            firstname=(user_data[config('ldap', 'userdata', 'name', 'given')] or [None])[0],
+            lastname=(user_data[config('ldap', 'userdata', 'name', 'family')] or [None])[0],
             username=user,
             groups=groups)
 

--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -163,10 +163,12 @@ def login():
         data['email'] = email
 
     # Make sure user is registered with Leihs
+    given = config('ldap', 'userdata', 'name', 'given')
+    family = config('ldap', 'userdata', 'name', 'family')
     register_user(
             email,
-            firstname=(user_data[config('ldap', 'userdata', 'name', 'given')] or [None])[0],
-            lastname=(user_data[config('ldap', 'userdata', 'name', 'family')] or [None])[0],
+            firstname=(user_data[given] or [None])[0],
+            lastname=(user_data[family] or [None])[0],
             username=user,
             groups=groups)
 


### PR DESCRIPTION
The register_user call would assume that the values for "given" and "family" from the configuration file were always "sn" and "givenName" respectively. Therefore, the programm would fail if a user changed those configuration values. This PR fixes this issue.