### PR TITLE
Tolerate trailing slash in URL

### DIFF
--- a/leihsldap/leihs_api.py
+++ b/leihsldap/leihs_api.py
@@ -33,7 +33,7 @@ def api(method: str, path: str, **kwargs) -> requests.models.Response:
     :param path: Path of the request URL
     :returns: HTTP response
     '''
-    base_url = config('leihs', 'url', allow_empty=False)
+    base_url = config('leihs', 'url', allow_empty=False).rstrip('/')
     url = f'{base_url}{path}'
     headers = {'Accept': 'application/json',
                'Content-Type': 'application/json',
@@ -127,7 +127,7 @@ def register_auth_system() -> None:
         'description': config('auth-system', 'description'),
         'enabled': True,
         'external_public_key': config('token', 'public_key'),
-        'external_sign_in_url': config('auth-system', 'url'),
+        'external_sign_in_url': config('auth-system', 'url').rstrip('/'),
         'id': config('auth-system', 'id', allow_empty=False),
         'internal_private_key': config('token', 'private_key'),
         'internal_public_key': config('token', 'public_key'),

--- a/leihsldap/web.py
+++ b/leihsldap/web.py
@@ -55,7 +55,7 @@ def error(error_id: str, code: int) -> tuple[str, int]:
     lang = request.accept_languages.best_match(__languages)
     logger.debug('Using language: %s', lang)
     error_data = __error[lang][error_id].copy()
-    error_data['leihs_url'] = config('leihs', 'url')
+    error_data['leihs_url'] = config('leihs', 'url').rstrip('/')
     error_data['i18n'] = __i18n[lang]
     return render_template('error.html', **error_data), code
 


### PR DESCRIPTION
This patch allows users to use URLs with and without slash in the configuration. This could have easily caused problems before.

This fixes #61